### PR TITLE
Hubot slack adapter

### DIFF
--- a/bin/hubot
+++ b/bin/hubot
@@ -6,4 +6,4 @@ set -e
 npm install
 export PATH="node_modules/.bin:node_modules/hubot/node_modules/.bin:$PATH"
 
-exec node_modules/.bin/hubot --adapter xmpp --name "ada" "$@"
+exec node_modules/.bin/hubot --adapter slack --name "ada" "$@"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "hubot-scripts": "^2.16.1",
     "hubot-simple-logger": "git+https://github.com/anarcher/hubot-simple-logger.git",
     "hubot-hostinger": "git+https://github.com/hostinger/hubot-hostinger.git#b8ffe84",
-    "hubot-xmpp": "0.2.1",
-    "hubot-chef": "2.7.0"
+    "hubot-chef": "2.7.0",
+    "hubot-slack": "^3.4.2"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
Use slack adapter because xmpp adapter sleeps in some channels and needs to be kicked and invited again, hopes to solve this with slack adapter