### PR TITLE
Change hubot-awex package's pinned version to master

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hubot-scripts": "^2.16.2",
     "hubot-simple-logger": "git+https://github.com/anarcher/hubot-simple-logger.git",
     "hubot-hostinger": "git+https://github.com/hostinger/hubot-hostinger.git#b8ffe84",
-    "hubot-awex": "git+https://github.com/hostinger/hubot-awex.git#23ba6a0bcf12914e7f748b87cf547c2df4fc742b",
+    "hubot-awex": "git+https://github.com/hostinger/hubot-awex.git#master",
     "hubot-chef": "2.7.0",
     "hubot-xmpp": "0.2.4"
   },


### PR DESCRIPTION
Change hubot-awex package's pinned version to master

hubot-awex does not have any releases so pin it to master branch.
https://docs.npmjs.com/files/package.json#git-urls-as-dependencies

related https://github.com/hostinger/hubot-awex/pull/1
@hostinger/devs