### PR TITLE
Bump hubot-awex version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hubot-scripts": "^2.16.2",
     "hubot-simple-logger": "git+https://github.com/anarcher/hubot-simple-logger.git",
     "hubot-hostinger": "git+https://github.com/hostinger/hubot-hostinger.git#b8ffe84",
-    "hubot-awex": "git+https://github.com/hostinger/hubot-awex.git#master",
+    "hubot-awex": "git+https://github.com/hostinger/hubot-awex.git#545caeac6315f8550046c4d28fb4ef54936bfbf7",
     "hubot-chef": "2.7.0",
     "hubot-xmpp": "0.2.4"
   },


### PR DESCRIPTION
Bump hubot-awex version to latest

Revert https://github.com/hostinger/hubot/pull/23


http://stackoverflow.com/questions/12478679/npm-install-vs-update-whats-the-difference
Server runs command `npm install` instead of `npm update` so it does not update package which is tagged to master branch.
@hostinger/devs