### PR TITLE
Revert "Remove redis package"

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -1,6 +1,7 @@
 [
   "hubot-cachethq",
   "hubot-help",
+  "hubot-redis-brain",
   "hubot-karma-classic",
   "hubot-pubsub",
   "hubot-jenkins",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "hubot-karma-classic": "^1.0.3",
     "hubot-links": "0.0.1",
     "hubot-pubsub": "^1.0.6",
+    "hubot-redis-brain": "0.0.3",
     "hubot-simple-logger": "git+https://github.com/anarcher/hubot-simple-logger.git",
     "hubot-xmpp": "0.2.6",
     "hubot-slack": "4.6.0"


### PR DESCRIPTION
Redis is required to make hubot persistent between restarts.

Reverts hostinger/hubot#59

Related https://github.com/hostinger/engineering/issues/1579